### PR TITLE
use the default implementation of Termination trait

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,21 @@ pub mod errors {
         pub code: ::reqwest::StatusCode
     }
 
+    #[derive(Fail, Debug)]
+    /// Files which have failed to download
+    pub struct DownloadsFailed {
+        pub files: Vec<(std::path::PathBuf, String)>
+    }
+
+    impl std::fmt::Display for DownloadsFailed {
+        fn fmt(&self, ft: &mut std::fmt::Formatter) -> std::fmt::Result {
+            let msgs = self.files.iter()
+                .map(|(f, err)| format!("\t{}: {}", f.display(), err))
+                .collect::<Vec<String>>();
+            write!(ft, "the following downloads failed:\n{}", msgs.join("\n"))
+        }
+    }
+
     /// Constructs a `Timeout` error
     pub fn timeout(seconds: u64) -> Error {
         Timeout(seconds).into()
@@ -29,5 +44,10 @@ pub mod errors {
     /// Constructs a `StatusCode` error
     pub fn status_code(code: ::reqwest::StatusCode) -> Error {
         (StatusCode { code }).into()
+    }
+
+    /// Constructs a `DownloadsFailed` error
+    pub fn download_failed(files: Vec<(std::path::PathBuf, String)>) -> Error {
+        DownloadsFailed { files }.into()
     }
 }

--- a/src/template.rs
+++ b/src/template.rs
@@ -18,7 +18,7 @@ pub struct Template {
 }
 
 impl Template {
-    pub fn from_file(file_path: &Path) -> errors::Result<Self> {
+    pub fn from_file<P: AsRef<Path>>(file_path: P) -> errors::Result<Self> {
         let mut cfg = config::Config::new();
         let mut file = fs::File::open(file_path)?;
         let mut contents = String::new();


### PR DESCRIPTION
Hello all,

The error handling in https://github.com/Technius/tempget/blob/f6c501c29908e58f877aa532214598351f79b52a/src/main.rs#L21-L28

may be duplicated with the [current implementation](https://doc.rust-lang.org/src/std/process.rs.html#1593-1600) of the `Termination` trait for `std::process`.

And the early exit in `run` https://github.com/Technius/tempget/blob/f6c501c29908e58f877aa532214598351f79b52a/src/main.rs#L45-L46

may not give any chance for `main` to take the control flow, so I've added a new error type.

The PR is simple and may not fit your style (sorry) but many thanks for any response.